### PR TITLE
Use cluster domain in eventshub certificates dnsNames

### DIFF
--- a/pkg/eventshub/105-certificate-service.yaml
+++ b/pkg/eventshub/105-certificate-service.yaml
@@ -43,7 +43,7 @@ spec:
     size: 2048
 
   dnsNames:
-    - {{ .serviceName }}.{{ .namespace }}.svc.cluster.local
+    - {{ .serviceName }}.{{ .namespace }}.svc.{{ .clusterDomain }}
   ipAddresses: # used for testing and port-forwarding
     - 127.0.0.1
 

--- a/pkg/eventshub/resources.go
+++ b/pkg/eventshub/resources.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	"knative.dev/pkg/logging"
+	"knative.dev/pkg/network"
 
 	"knative.dev/reconciler-test/pkg/environment"
 	eventshubrbac "knative.dev/reconciler-test/pkg/eventshub/rbac"
@@ -112,6 +113,7 @@ func Install(name string, options ...EventsHubOption) feature.StepFn {
 			"image":          ImageFromContext(ctx),
 			"isReceiver":     isReceiver,
 			"withEnforceTLS": isEnforceTLS,
+			"clusterDomain":  network.GetClusterDomainName(),
 		}
 
 		// Install ServiceAccount, Role, RoleBinding


### PR DESCRIPTION
Currently the domain of the eventshub certificate dnsNames are hard coded to `cluster.local`.
This leads to a couple of TLS test failures when the tests are running in kind with a custom cluster domain (e.g. in case of the eventing e2e tests via GH actions).

This PR addresses it and uses the ClusterDomain from the cluster on which the test is running on.