### PR TITLE
Add hold annotation for istio-proxy

### DIFF
--- a/pkg/eventshub/eventshub_test.go
+++ b/pkg/eventshub/eventshub_test.go
@@ -154,6 +154,7 @@ func ExampleIstioAnnotation() {
 	//   labels:
 	//     app: eventshub-hubhub
 	//   annotations:
+	//       proxy.istio.io/config: "{ 'holdApplicationUntilProxyStarts': true }"
 	//       sidecar.istio.io/inject: "true"
 	//       sidecar.istio.io/rewriteAppHTTPProbers: "true"
 	// spec:

--- a/pkg/manifest/options.go
+++ b/pkg/manifest/options.go
@@ -86,6 +86,7 @@ func WithIstioPodAnnotations(cfg map[string]interface{}) {
 	podAnnotations := map[string]interface{}{
 		"sidecar.istio.io/inject":                "true",
 		"sidecar.istio.io/rewriteAppHTTPProbers": "true",
+		"proxy.istio.io/config":                  "{ 'holdApplicationUntilProxyStarts': true }",
 	}
 
 	WithAnnotations(podAnnotations)(cfg)


### PR DESCRIPTION
# Changes
- Adds an annotation to the istio-proxy to hold the application start until the proxy is ready
- Verified on https://github.com/openshift-knative/serverless-operator/pull/2228

/kind enhancement
