### PR TITLE
:lady_beetle: Call the Istio' quit when the eventshub is closed

### DIFF
--- a/pkg/eventshub/istio_quit.go
+++ b/pkg/eventshub/istio_quit.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2023 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package eventshub
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"syscall"
+
+	"knative.dev/pkg/logging"
+)
+
+// maybeQuitIstioProxy shuts down Istio's proxy when available.
+func maybeQuitIstioProxy(ctx context.Context) {
+	log := logging.FromContext(ctx)
+	req, _ := http.NewRequest(http.MethodPost, "http://localhost:15020/quitquitquit", nil)
+
+	_, err := http.DefaultClient.Do(req)
+
+	if err != nil && !errors.Is(err, syscall.ECONNREFUSED) {
+		log.Warn("Ignore this warning if Istio proxy is not used on this pod", err)
+	}
+}


### PR DESCRIPTION
# Changes

- :lady_beetle: Call the quit when the eventshub is closed

/kind bug

Fixes #590

**Release Note**

```release-note
The eventshub will call the Istio's /quitquitquit endpoint at exit
```