### PR TITLE
Update to golang 1.20

### DIFF
--- a/.github/workflows/go-test-windows.yaml
+++ b/.github/workflows/go-test-windows.yaml
@@ -28,10 +28,10 @@ jobs:
 
     steps:
 
-      - name: Set up Go 1.18
+      - name: Set up Go 1.20
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18.x
+          go-version: 1.20.x
         id: go
 
       - name: Set git autocrlf to input

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -11,7 +11,7 @@ jobs:
   e2e-tests:
     strategy:
       matrix:
-        go-version: [ 1.18.x ]
+        go-version: [ 1.20.x ]
         platform: [ ubuntu-latest ]
         kind-version: [ 0.14.0 ]
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module knative.dev/reconciler-test
 
-go 1.18
+go 1.20
 
 require (
 	github.com/cloudevents/conformance v0.2.0


### PR DESCRIPTION
Update go version for tests to 1.20, as we had some issues in #564

```
Error: vendor/k8s.io/kube-openapi/pkg/cached/cache.go:242:16: undefined: atomic.Pointer
note: module requires Go 1.19
Error: vendor/go.uber.org/multierr/error.go:224:20: undefined: atomic.Bool
note: module requires Go 1.19
Error: vendor/k8s.io/client-go/tools/cache/synctrack/lazy.go:29:15: undefined: atomic.Pointer
note: module requires Go 1.20
```