### PR TITLE
Fix forwarder SINK URL

### DIFF
--- a/pkg/eventshub/resources.go
+++ b/pkg/eventshub/resources.go
@@ -158,7 +158,7 @@ func Install(name string, options ...EventsHubOption) feature.StepFn {
 			// No event recording desired, just logging.
 			envs[EventLogsEnv] = "logger"
 			cfg["envs"] = envs
-			cfg["sink"] = sinkURL
+			cfg["sink"] = sinkURL.URL.String()
 
 			// Deploy Forwarder
 			if _, err := manifest.InstallYamlFS(ctx, forwarderTemplates, cfg); err != nil {


### PR DESCRIPTION
Downstream I'm getting this `SINK` value due to
the fact that `sinkURL` is now an `Addressable`:

```
        apiVersion: serving.knative.dev/v1
        kind: Service
        metadata:
          name: sink-nwvhvrgz
          namespace: test-fbszrpbn
        spec:
          template:
            spec:
              containers:
                - env:
                    - name: NAME
                      value: sink-nwvhvrgz
                    - name: NAMESPACE
                      value: test-fbszrpbn
                    - name: SINK
                      value:
                        <nil> http://sink-nwvhvrgz-twzpetzr.test-fbszrpbn.svc.cluster.local <nil>: null
                    - name: EVENT_GENERATORS
                      value: forwarder
                    - name: EVENT_LOGS
                      value: logger
                    - name: K_CONFIG_LOGGING
                      value: '{"zap-logger-config":"{\n  \"level\": \"info\",\n  \"development\": false,\n  \"outputPaths\": [\"stdout\"],\n  \"errorOutputPaths\": [\"stderr\"],\n  \"encoding\": \"json\",\n  \"encoderConfig\": {\n    \"timeKey\": \"ts\",\n    \"levelKey\": \"level\",\n    \"nameKey\": \"logger\",\n    \"callerKey\": \"caller\",\n    \"messageKey\": \"msg\",\n    \"stacktraceKey\": \"stacktrace\",\n    \"lineEnding\": \"\",\n    \"levelEncoder\": \"\",\n    \"timeEncoder\": \"iso8601\",\n    \"durationEncoder\": \"\",\n    \"callerEncoder\": \"\"\n  }\n}\n"}'
                    - name: K_CONFIG_TRACING
                      value: '{"backend":"zipkin","debug":"false","sample-rate":"1","zipkin-endpoint":"http://cluster-collector-collector-headless.istio-system.svc:9411/api/v2/spans"}'
                  image: quay.io/openshift-knative/eventing/eventshub:v1.10
                  imagePullPolicy: IfNotPresent
                  name: eventshub-forwarder
              serviceAccountName: sink-nwvhvrgz
```

<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Fix forwarder URL
- Print resource when failing to create/update a resource manifest

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind bug

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
