### PR TITLE
Support OIDC in eventshub receiver

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -84,7 +84,7 @@ jobs:
 
         # Run the tests tagged as e2e on the KinD cluster.
         go run gotest.tools/gotestsum@v1.8.0 --format testname -- \
-          -race -count=1 -timeout=15m -tags=e2e ./test/...
+          -race -count=1 -timeout=1h -tags=e2e ./test/...
 
     - name: Gather Failure Data
       if: ${{ failure() }}

--- a/pkg/eventshub/options.go
+++ b/pkg/eventshub/options.go
@@ -202,6 +202,11 @@ func DropEventsResponseHeaders(headers map[string]string) EventsHubOption {
 	)
 }
 
+// OIDCReceiverAudience sets the expected audience for received OIDC tokens on the receiver side
+func OIDCReceiverAudience(aud string) EventsHubOption {
+	return compose(envOption(OIDCReceiverAudienceEnv, aud), envOIDCEnabled())
+}
+
 // --- Sender options
 
 // InitialSenderDelay defines how much the sender has to wait (in millisecond), when started, before start sending events.
@@ -281,6 +286,11 @@ func OIDCExpiredToken() EventsHubOption {
 // OIDCInvalidAudience creates an OIDC token with an invalid audience
 func OIDCInvalidAudience() EventsHubOption {
 	return compose(envOption(OIDCGenerateInvalidAudienceTokenEnv, "true"), envOIDCEnabled())
+}
+
+// OIDCSinkAudience sets the Audience of the Sink
+func OIDCSinkAudience(aud string) EventsHubOption {
+	return oidcSinkAudience(&aud)
 }
 
 func oidcSinkAudience(aud *string) EventsHubOption {

--- a/pkg/eventshub/rbac/101-rbac.yaml
+++ b/pkg/eventshub/rbac/101-rbac.yaml
@@ -45,3 +45,20 @@ subjects:
   - kind: ServiceAccount
     name: {{ .name }}
     namespace: {{ .namespace }}
+
+{{ if and .withOIDCAuth .isReceiver }}
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator # e.g. to do a token review
+subjects:
+  - kind: ServiceAccount
+    name: {{ .name }}
+    namespace: {{ .namespace }}
+{{ end }}

--- a/pkg/eventshub/receiver/receiver.go
+++ b/pkg/eventshub/receiver/receiver.go
@@ -29,10 +29,14 @@ import (
 	cloudeventshttp "github.com/cloudevents/sdk-go/v2/protocol/http"
 	"github.com/kelseyhightower/envconfig"
 	"go.uber.org/zap"
+	authv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	"knative.dev/pkg/logging"
 
 	"knative.dev/reconciler-test/pkg/eventshub"
 
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	"knative.dev/reconciler-test/pkg/eventshub/dropevents"
 )
 
@@ -53,6 +57,9 @@ type Receiver struct {
 	skipResponseHeaders map[string]string
 	skipResponseBody    string
 	EnforceTLS          bool
+	oidcAudience        string
+
+	kubeclient kubernetes.Interface
 }
 
 type envConfig struct {
@@ -61,6 +68,9 @@ type envConfig struct {
 
 	// EnforceTLS is used to enforce TLS.
 	EnforceTLS bool `envconfig:"ENFORCE_TLS" default:"false"`
+
+	// OIDCAudience is the audience required for OIDC tokens reaching the receiver
+	OIDCAudience string `envconfig:"OIDC_AUDIENCE" default:""`
 
 	// ResponseWaitTime is the seconds to wait for the eventshub to write any response
 	ResponseWaitTime int `envconfig:"RESPONSE_WAIT_TIME" default:"0" required:"false"`
@@ -143,6 +153,8 @@ func NewFromEnv(ctx context.Context, eventLogs *eventshub.EventLogs) *Receiver {
 		skipResponseCode:    env.SkipResponseCode,
 		skipResponseBody:    env.SkipResponseBody,
 		skipResponseHeaders: env.SkipResponseHeaders,
+		oidcAudience:        env.OIDCAudience,
+		kubeclient:          kubeclient.Get(ctx),
 	}
 }
 
@@ -211,6 +223,14 @@ func (o *Receiver) ServeHTTP(writer http.ResponseWriter, request *http.Request) 
 		rejectErr = fmt.Errorf("failed to enforce TLS connection for request %s", request.URL.String())
 	}
 
+	var rejectErrStatusCode int
+	if o.oidcAudience != "" {
+		if err := o.validateJWT(request); err != nil {
+			rejectErr = err
+			rejectErrStatusCode = http.StatusUnauthorized
+		}
+	}
+
 	m := cloudeventshttp.NewMessageFromHttpRequest(request)
 	defer m.Finish(nil)
 
@@ -269,7 +289,13 @@ func (o *Receiver) ServeHTTP(writer http.ResponseWriter, request *http.Request) 
 		for headerKey, headerValue := range o.skipResponseHeaders {
 			writer.Header().Set(headerKey, headerValue)
 		}
-		writer.WriteHeader(http.StatusBadRequest)
+
+		if rejectErrStatusCode > 0 {
+			writer.WriteHeader(rejectErrStatusCode)
+		} else {
+			writer.WriteHeader(http.StatusBadRequest)
+		}
+
 	} else if shouldSkip {
 		// Trigger a redelivery
 		for headerKey, headerValue := range o.skipResponseHeaders {
@@ -280,6 +306,41 @@ func (o *Receiver) ServeHTTP(writer http.ResponseWriter, request *http.Request) 
 	} else {
 		o.replyFunc(o.ctx, writer, eventInfo)
 	}
+}
+
+func (o *Receiver) validateJWT(request *http.Request) error {
+	authHeader := request.Header.Get("Authorization")
+	if authHeader == "" {
+		return fmt.Errorf("could not get Authorization header")
+	}
+
+	token := strings.TrimPrefix(authHeader, "Bearer ")
+	if len(token) == len(authHeader) {
+		return fmt.Errorf("could not get Bearer token from header")
+	}
+
+	tokenReview, err := o.kubeclient.AuthenticationV1().TokenReviews().Create(o.ctx, &authv1.TokenReview{
+		Spec: authv1.TokenReviewSpec{
+			Token: token,
+			Audiences: []string{
+				o.oidcAudience,
+			},
+		},
+	}, metav1.CreateOptions{})
+
+	if err != nil {
+		return fmt.Errorf("could not get token review: %w", err)
+	}
+
+	if err := tokenReview.Status.Error; err != "" {
+		return fmt.Errorf(err)
+	}
+
+	if !tokenReview.Status.Authenticated {
+		return fmt.Errorf("user not authenticated")
+	}
+
+	return nil
 }
 
 func isTLS(request *http.Request) bool {

--- a/pkg/eventshub/utils.go
+++ b/pkg/eventshub/utils.go
@@ -43,6 +43,7 @@ const (
 	OIDCGenerateInvalidAudienceTokenEnv    = "OIDC_GENERATE_INVALID_AUDIENCE_TOKEN"
 	OIDCGenerateCorruptedSignatureTokenEnv = "OIDC_GENERATE_CORRUPTED_SIG_TOKEN"
 	OIDCSinkAudienceEnv                    = "OIDC_SINK_AUDIENCE"
+	OIDCReceiverAudienceEnv                = "OIDC_AUDIENCE"
 	OIDCTokenEnv                           = "OIDC_TOKEN"
 
 	EnforceTLS = "ENFORCE_TLS"

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -25,6 +25,6 @@ initialize "$@"
 
 set -Eeuo pipefail
 
-go_test_e2e -timeout 10m ./test/...
+go_test_e2e -timeout 1h ./test/...
 
 success

--- a/test/e2e/eventshub/oidc_test.go
+++ b/test/e2e/eventshub/oidc_test.go
@@ -27,7 +27,6 @@ import (
 
 	cetest "github.com/cloudevents/sdk-go/v2/test"
 
-	"knative.dev/pkg/system"
 	"knative.dev/reconciler-test/pkg/environment"
 	"knative.dev/reconciler-test/pkg/eventshub"
 	"knative.dev/reconciler-test/pkg/eventshub/assert"
@@ -42,7 +41,7 @@ func TestEventsHubOIDCAuth(t *testing.T) {
 	ctx, env := global.Environment(
 		environment.Managed(t),
 		environment.WithPollTimings(4*time.Second, 12*time.Minute),
-		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithKnativeNamespace("knative-reconciler-test"),
 		knative.WithLoggingConfig,
 		knative.WithTracingConfig,
 		k8s.WithEventListener,

--- a/test/e2e/eventshub/oidc_test.go
+++ b/test/e2e/eventshub/oidc_test.go
@@ -1,0 +1,206 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package eventshub_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	cetest "github.com/cloudevents/sdk-go/v2/test"
+
+	"knative.dev/pkg/system"
+	"knative.dev/reconciler-test/pkg/environment"
+	"knative.dev/reconciler-test/pkg/eventshub"
+	"knative.dev/reconciler-test/pkg/eventshub/assert"
+	"knative.dev/reconciler-test/pkg/feature"
+	"knative.dev/reconciler-test/pkg/k8s"
+	"knative.dev/reconciler-test/pkg/knative"
+)
+
+func TestEventsHubOIDCAuth(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := global.Environment(
+		environment.Managed(t),
+		environment.WithPollTimings(4*time.Second, 12*time.Minute),
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+	)
+
+	env.Test(ctx, t, validToken())
+	env.Test(ctx, t, invalidAudience())
+	env.Test(ctx, t, expiredToken())
+	env.Test(ctx, t, corruptedSignatureToken())
+}
+
+func validToken() *feature.Feature {
+	f := feature.NewFeatureNamed("OIDC - valid token")
+
+	sinkName := feature.MakeRandomK8sName("sink")
+	sourceName := feature.MakeRandomK8sName("source")
+	audience := "my-sink-audience"
+
+	event := cetest.FullEvent()
+
+	f.Setup("deploy receiver", eventshub.Install(sinkName,
+		eventshub.StartReceiver,
+		eventshub.OIDCReceiverAudience(audience)))
+
+	f.Requirement("deploy sender", func(ctx context.Context, t feature.T) {
+		eventshub.Install(sourceName,
+			eventshub.StartSenderToResource(eventshub.ReceiverGVR(ctx), sinkName),
+			eventshub.InputEvent(event),
+			eventshub.OIDCSinkAudience(audience),
+		)(ctx, t)
+	})
+
+	f.Assert("Receive event", assert.OnStore(sinkName).
+		MatchReceivedEvent(cetest.HasId(event.ID())).
+		AtLeast(1),
+	)
+
+	f.Assert("Sent event", assert.OnStore(sourceName).
+		MatchSentEvent(cetest.HasId(event.ID())).
+		AtLeast(1),
+	)
+
+	return f
+}
+
+func invalidAudience() *feature.Feature {
+	f := feature.NewFeatureNamed("OIDC - invalid audience")
+
+	sinkName := feature.MakeRandomK8sName("sink")
+	sourceName := feature.MakeRandomK8sName("source")
+
+	event := cetest.FullEvent()
+
+	f.Setup("deploy receiver", eventshub.Install(sinkName,
+		eventshub.StartReceiver,
+		eventshub.OIDCReceiverAudience("my-sink-audience")))
+
+	f.Requirement("deploy sender", func(ctx context.Context, t feature.T) {
+		eventshub.Install(sourceName,
+			eventshub.StartSenderToResource(eventshub.ReceiverGVR(ctx), sinkName),
+			eventshub.InputEvent(event),
+			eventshub.OIDCSinkAudience("some-other-audience"),
+		)(ctx, t)
+	})
+
+	f.Assert("Sink does not receive event", assert.OnStore(sinkName).
+		MatchReceivedEvent(cetest.HasId(event.ID())).
+		Not(),
+	)
+
+	f.Assert("Source sent event", assert.OnStore(sourceName).
+		MatchSentEvent(cetest.HasId(event.ID())).
+		Exact(1),
+	)
+
+	f.Assert("Source gets 401 response", assert.OnStore(sourceName).
+		Match(assert.MatchStatusCode(401)).
+		Exact(1),
+	)
+
+	return f
+}
+
+func expiredToken() *feature.Feature {
+	f := feature.NewFeatureNamed("OIDC - expried token")
+
+	sinkName := feature.MakeRandomK8sName("sink")
+	sourceName := feature.MakeRandomK8sName("source")
+	audience := "my-sink-audience"
+
+	event := cetest.FullEvent()
+
+	f.Setup("deploy receiver", eventshub.Install(sinkName,
+		eventshub.StartReceiver,
+		eventshub.OIDCReceiverAudience(audience)))
+
+	f.Requirement("deploy sender", func(ctx context.Context, t feature.T) {
+		eventshub.Install(sourceName,
+			eventshub.StartSenderToResource(eventshub.ReceiverGVR(ctx), sinkName),
+			eventshub.InputEvent(event),
+			eventshub.OIDCSinkAudience(audience),
+			eventshub.OIDCExpiredToken(),
+		)(ctx, t)
+	})
+
+	f.Assert("Sink does not receive event", assert.OnStore(sinkName).
+		MatchReceivedEvent(cetest.HasId(event.ID())).
+		Not(),
+	)
+
+	f.Assert("Source sent event", assert.OnStore(sourceName).
+		MatchSentEvent(cetest.HasId(event.ID())).
+		Exact(1),
+	)
+
+	f.Assert("Source gets 401 response", assert.OnStore(sourceName).
+		Match(assert.MatchStatusCode(401)).
+		Exact(1),
+	)
+
+	return f
+}
+
+func corruptedSignatureToken() *feature.Feature {
+	f := feature.NewFeatureNamed("OIDC - expried token")
+
+	sinkName := feature.MakeRandomK8sName("sink")
+	sourceName := feature.MakeRandomK8sName("source")
+	audience := "my-sink-audience"
+
+	event := cetest.FullEvent()
+
+	f.Setup("deploy receiver", eventshub.Install(sinkName,
+		eventshub.StartReceiver,
+		eventshub.OIDCReceiverAudience(audience)))
+
+	f.Requirement("deploy sender", func(ctx context.Context, t feature.T) {
+		eventshub.Install(sourceName,
+			eventshub.StartSenderToResource(eventshub.ReceiverGVR(ctx), sinkName),
+			eventshub.InputEvent(event),
+			eventshub.OIDCSinkAudience(audience),
+			eventshub.OIDCCorruptedSignature(),
+		)(ctx, t)
+	})
+
+	f.Assert("Sink does not receive event", assert.OnStore(sinkName).
+		MatchReceivedEvent(cetest.HasId(event.ID())).
+		Not(),
+	)
+
+	f.Assert("Source sent event", assert.OnStore(sourceName).
+		MatchSentEvent(cetest.HasId(event.ID())).
+		Exact(1),
+	)
+
+	f.Assert("Source gets 401 response", assert.OnStore(sourceName).
+		Match(assert.MatchStatusCode(401)).
+		Exact(1),
+	)
+
+	return f
+}


### PR DESCRIPTION
Fixes https://github.com/knative/eventing/issues/7334

# Changes

- :gift: Add OIDC support to eventshub receiver

As soon as an eventshub receiver was setup with an audience (via `OIDCReceiverAudience(aud)`), it will check verify the JWTs of incoming requests (and respond with a 401, if failed).

**Hints for reviewers:**
* Added the `OIDCSinkAudience(aud)` option too, to define the audience of the sink, which is helpful/needed, if the audience of the sink can't be determined by the source itself (e.g. when the sink does not provide the `.status.address.audience` field)
* We can add the OIDC service account name to the eventInfo and then later base some asserter on it, but I didn't see a real usecase for it at that time of the OIDC implementation
* We verify the tokens with the TokenReviewAPI to not add another dependency to some OIDC library (e.g. coreos/go-oidc) and safe the setup.

```release-note
Support OIDC in eventshub receiver
```