### PR TITLE
Use ParallelTest*() for OIDC tests

### DIFF
--- a/test/e2e/eventshub/oidc_test.go
+++ b/test/e2e/eventshub/oidc_test.go
@@ -47,8 +47,8 @@ func TestEventsHubOIDCAuth(t *testing.T) {
 		k8s.WithEventListener,
 	)
 
-	env.Test(ctx, t, validToken())
-	env.TestSet(ctx, t, invalidTokens())
+	env.ParallelTest(ctx, t, validToken())
+	env.ParallelTestSet(ctx, t, invalidTokens())
 }
 
 func validToken() *feature.Feature {


### PR DESCRIPTION
Use `ParallelTest()` and `ParallelTestSet()` to speed up OIDC e2e tests.

Follow up on https://github.com/knative-extensions/reconciler-test/pull/612#discussion_r1363585112