### PR TITLE
Configure sender with CA certs when provided

### DIFF
--- a/pkg/eventshub/sender/sender.go
+++ b/pkg/eventshub/sender/sender.go
@@ -261,7 +261,7 @@ func Start(ctx context.Context, logs *eventshub.EventLogs, clientOpts ...eventsh
 }
 
 func createClient(ctx context.Context, env generator, logs *eventshub.EventLogs) (*nethttp.Client, *nethttp.Transport, error) {
-	if env.EnforceTLS {
+	if env.EnforceTLS || env.CACerts != "" {
 		caCertPool, err := x509.SystemCertPool()
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to create cert pool %s: %w", env.Sink, err)


### PR DESCRIPTION
This will enable us to run tests with both OIDC and TLS enabled.

