### PR TITLE
use context poll interval/timeout in DeleteResources

### DIFF
--- a/pkg/environment/timings.go
+++ b/pkg/environment/timings.go
@@ -23,6 +23,8 @@ import (
 	"knative.dev/reconciler-test/pkg/state"
 )
 
+// this has been moved to state pkg to break cycle between environment and feature package,
+// keeping the consts here for backwards API compatibility
 const (
 	DefaultPollInterval = 3 * time.Second
 	DefaultPollTimeout  = 2 * time.Minute

--- a/pkg/feature/feature.go
+++ b/pkg/feature/feature.go
@@ -31,8 +31,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/injection/clients/dynamicclient"
-	"knative.dev/reconciler-test/pkg/environment"
-
 	"knative.dev/reconciler-test/pkg/state"
 )
 
@@ -229,7 +227,7 @@ func DeleteResources(ctx context.Context, t T, refs []corev1.ObjectReference) er
 
 	var lastResource corev1.ObjectReference // One still present resource
 
-	interval, timeout := environment.PollTimingsFromContext(ctx)
+	interval, timeout := state.PollTimingsFromContext(ctx)
 	err := wait.Poll(interval, timeout, func() (bool, error) {
 		for _, ref := range refs {
 			gv, err := schema.ParseGroupVersion(ref.APIVersion)

--- a/pkg/feature/feature.go
+++ b/pkg/feature/feature.go
@@ -23,7 +23,6 @@ import (
 	"runtime"
 	"strings"
 	"sync"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -32,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/injection/clients/dynamicclient"
+	"knative.dev/reconciler-test/pkg/environment"
 
 	"knative.dev/reconciler-test/pkg/state"
 )
@@ -229,7 +229,8 @@ func DeleteResources(ctx context.Context, t T, refs []corev1.ObjectReference) er
 
 	var lastResource corev1.ObjectReference // One still present resource
 
-	err := wait.Poll(time.Second, 4*time.Minute, func() (bool, error) {
+	interval, timeout := environment.PollTimingsFromContext(ctx)
+	err := wait.Poll(interval, timeout, func() (bool, error) {
 		for _, ref := range refs {
 			gv, err := schema.ParseGroupVersion(ref.APIVersion)
 			if err != nil {

--- a/pkg/state/timings.go
+++ b/pkg/state/timings.go
@@ -14,13 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package environment
+package state
 
 import (
 	"context"
 	"time"
-
-	"knative.dev/reconciler-test/pkg/state"
 )
 
 const (
@@ -28,15 +26,27 @@ const (
 	DefaultPollTimeout  = 2 * time.Minute
 )
 
+type timingsKey struct{}
+type timingsType struct {
+	interval time.Duration
+	timeout  time.Duration
+}
+
 // ContextWithPollTimings returns a context with poll timings set
 func ContextWithPollTimings(ctx context.Context, interval, timeout time.Duration) context.Context {
-	return state.ContextWithPollTimings(ctx, interval, timeout)
+	return context.WithValue(ctx, timingsKey{}, timingsType{
+		interval: interval,
+		timeout:  timeout,
+	})
 }
 
 // PollTimingsFromContext will get the previously set poll timing from context,
 // or return the defaults if not found.
-// - values from context.
+// - values from  context.
 // - defaults.
 func PollTimingsFromContext(ctx context.Context) (time.Duration, time.Duration) {
-	return state.PollTimingsFromContext(ctx)
+	if t, ok := ctx.Value(timingsKey{}).(timingsType); ok {
+		return t.interval, t.timeout
+	}
+	return DefaultPollInterval, DefaultPollTimeout
 }


### PR DESCRIPTION
- :broom: Use context poll interval/timeout in DeleteResources
/kind cleanup

Deleting resources with finalizer also requires reconciliation, so waiting for a resource to be deleted is in principle no different to waiting for it to become Ready. In some cases it makes sense to increase the timeouts for waiting for deleted resources. Therefore, we'll apply the same poll interval/timeouts for waiting for deletion as set in ContextWithPollTimings, instead of the original hardcoded values.

Also moves the ContextWithPollTimings and PollTimingsFromContext to `state` package to break dependency cycle

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
feature.DeleteResources now uses poll interval/timeouts from Context for waiting for the resources to be deleted, instead of the original hardcoded values
```