### PR TITLE
Add matcher for used OIDC user name

### DIFF
--- a/pkg/eventshub/assert/event_info_matchers.go
+++ b/pkg/eventshub/assert/event_info_matchers.go
@@ -114,6 +114,20 @@ func MatchStatusCode(statusCode int) eventshub.EventInfoMatcher {
 	}
 }
 
+// MatchOIDCUser matches the OIDC username used for the request
+func MatchOIDCUser(username string) eventshub.EventInfoMatcher {
+	return func(info eventshub.EventInfo) error {
+		if info.OIDCUserInfo == nil {
+			return fmt.Errorf("event OIDC username don't match. Expected: '%s', Actual: nil", username)
+		}
+		if info.OIDCUserInfo.Username != username {
+			return fmt.Errorf("event OIDC username don't match. Expected: '%s', Actual: %s", username, info.OIDCUserInfo.Username)
+		}
+
+		return nil
+	}
+}
+
 // MatchHeartBeatsImageMessage matches that the data field of the event, in the format of the heartbeats image, contains the following msg field
 func MatchHeartBeatsImageMessage(expectedMsg string) cetest.EventMatcher {
 	return cetest.AllOf(

--- a/pkg/eventshub/assert/event_info_matchers.go
+++ b/pkg/eventshub/assert/event_info_matchers.go
@@ -126,10 +126,10 @@ func MatchStatusCode(statusCode int) eventshub.EventInfoMatcher {
 func MatchOIDCUser(username string) eventshub.EventInfoMatcher {
 	return func(info eventshub.EventInfo) error {
 		if info.OIDCUserInfo == nil {
-			return fmt.Errorf("event OIDC username don't match. Expected: '%s', Actual: nil", username)
+			return fmt.Errorf("event OIDC usernames don't match: Expected %q, but no OIDC user info in the event", username)
 		}
 		if info.OIDCUserInfo.Username != username {
-			return fmt.Errorf("event OIDC username don't match. Expected: '%s', Actual: %s", username, info.OIDCUserInfo.Username)
+			return fmt.Errorf("event OIDC usernames don't match. Expected: %q, Actual: %q", username, info.OIDCUserInfo.Username)
 		}
 
 		return nil
@@ -159,7 +159,7 @@ func MatchOIDCUserFromResource(gvr schema.GroupVersionResource, resourceName str
 
 		obj := &AuthenticatableType{}
 		if err = runtime.DefaultUnstructuredConverter.FromUnstructured(us.Object, obj); err != nil {
-			return fmt.Errorf("error from DefaultUnstructured.Dynamiconverter. %w", err)
+			return fmt.Errorf("error from DefaultUnstructured.Dynamiconverter: %w", err)
 		}
 
 		if obj.Status.Auth == nil || obj.Status.Auth.ServiceAccountName == nil {

--- a/pkg/eventshub/assert/event_info_matchers.go
+++ b/pkg/eventshub/assert/event_info_matchers.go
@@ -19,13 +19,14 @@ package assert
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/injection/clients/dynamicclient"
 	"knative.dev/reconciler-test/pkg/environment"
-	"strings"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	cetest "github.com/cloudevents/sdk-go/v2/test"

--- a/pkg/eventshub/assert/event_info_matchers.go
+++ b/pkg/eventshub/assert/event_info_matchers.go
@@ -135,7 +135,7 @@ func MatchOIDCUser(username string) eventshub.EventInfoMatcher {
 	}
 }
 
-func MatchOIDCUserFromResource(gvr schema.GroupVersionResource, name string) eventshub.EventInfoMatcherCtx {
+func MatchOIDCUserFromResource(gvr schema.GroupVersionResource, resourceName string) eventshub.EventInfoMatcherCtx {
 
 	type AuthenticatableType struct {
 		metav1.TypeMeta   `json:",inline"`
@@ -150,7 +150,7 @@ func MatchOIDCUserFromResource(gvr schema.GroupVersionResource, name string) eve
 
 		env := environment.FromContext(ctx)
 
-		us, err := dynamicclient.Get(ctx).Resource(gvr).Namespace(env.Namespace()).Get(ctx, name, metav1.GetOptions{})
+		us, err := dynamicclient.Get(ctx).Resource(gvr).Namespace(env.Namespace()).Get(ctx, resourceName, metav1.GetOptions{})
 		if err != nil {
 			return fmt.Errorf("error getting resource: %w", err)
 		}

--- a/pkg/eventshub/assert/event_info_matchers.go
+++ b/pkg/eventshub/assert/event_info_matchers.go
@@ -135,6 +135,7 @@ func MatchOIDCUser(username string) eventshub.EventInfoMatcher {
 	}
 }
 
+// MatchOIDCUserFromResource matches the given resources OIDC identifier
 func MatchOIDCUserFromResource(gvr schema.GroupVersionResource, resourceName string) eventshub.EventInfoMatcherCtx {
 
 	type AuthenticatableType struct {

--- a/pkg/eventshub/event_info.go
+++ b/pkg/eventshub/event_info.go
@@ -21,9 +21,10 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	v1 "k8s.io/api/authentication/v1"
 	"strings"
 	"time"
+
+	v1 "k8s.io/api/authentication/v1"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 )

--- a/pkg/eventshub/event_info.go
+++ b/pkg/eventshub/event_info.go
@@ -92,9 +92,6 @@ type EventInfo struct {
 
 	// OIDCUserInfo is the user info of the subject of the OIDC token used in the request
 	OIDCUserInfo *v1.UserInfo `json:"oidcUserInfo,omitempty"`
-
-	// OIDCClaims are the claims of the OIDC token used in the request
-	OIDCClaims *KubernetesClaims `json:"oidcClaims,omitempty"`
 }
 
 // Pretty print the event. Meant for debugging.
@@ -194,13 +191,4 @@ func IsInsecureCipherSuite(conn *tls.ConnectionState) bool {
 		}
 	}
 	return res
-}
-
-type KubernetesClaims struct {
-	Issuer    string     `json:"iss,omitempty"`
-	Audience  []string   `json:"aud,omitempty"`
-	Subject   string     `json:"sub,omitempty"`
-	Expiry    *time.Time `json:"exp,omitempty"`
-	IssuedAt  *time.Time `json:"iat,omitempty"`
-	NotBefore *time.Time `json:"nbf,omitempty"`
 }

--- a/pkg/eventshub/event_info.go
+++ b/pkg/eventshub/event_info.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
+	v1 "k8s.io/api/authentication/v1"
 	"strings"
 	"time"
 
@@ -87,6 +88,12 @@ type EventInfo struct {
 
 	// AdditionalInfo can be used by event generator implementations to add more event details
 	AdditionalInfo map[string]interface{} `json:"additionalInfo"`
+
+	// OIDCUserInfo is the user info of the subject of the OIDC token used in the request
+	OIDCUserInfo *v1.UserInfo `json:"oidcUserInfo,omitempty"`
+
+	// OIDCClaims are the claims of the OIDC token used in the request
+	OIDCClaims *KubernetesClaims `json:"oidcClaims,omitempty"`
 }
 
 // Pretty print the event. Meant for debugging.
@@ -186,4 +193,13 @@ func IsInsecureCipherSuite(conn *tls.ConnectionState) bool {
 		}
 	}
 	return res
+}
+
+type KubernetesClaims struct {
+	Issuer    string     `json:"iss,omitempty"`
+	Audience  []string   `json:"aud,omitempty"`
+	Subject   string     `json:"sub,omitempty"`
+	Expiry    *time.Time `json:"exp,omitempty"`
+	IssuedAt  *time.Time `json:"iat,omitempty"`
+	NotBefore *time.Time `json:"nbf,omitempty"`
 }

--- a/pkg/eventshub/receiver/receiver.go
+++ b/pkg/eventshub/receiver/receiver.go
@@ -19,8 +19,6 @@ package receiver
 import (
 	"context"
 	"crypto/tls"
-	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
@@ -228,18 +226,12 @@ func (o *Receiver) ServeHTTP(writer http.ResponseWriter, request *http.Request) 
 	}
 
 	var oidcUser *authv1.UserInfo
-	var oidcClaims *eventshub.KubernetesClaims
 	if o.oidcAudience != "" {
 		var err error
 		oidcUser, err = o.verifyJWT(request)
 		if err != nil {
 			rejectErr = err
 			statusCode = http.StatusUnauthorized
-		} else {
-			oidcClaims, err = o.getOIDCClaims(request)
-			if err != nil {
-				logging.FromContext(o.ctx).Warnf("failed to get OIDC claims: %s", err)
-			}
 		}
 	}
 
@@ -292,7 +284,6 @@ func (o *Receiver) ServeHTTP(writer http.ResponseWriter, request *http.Request) 
 		Connection:   eventshub.TLSConnectionStateToConnection(request.TLS),
 		StatusCode:   statusCode,
 		OIDCUserInfo: oidcUser,
-		OIDCClaims:   oidcClaims,
 	}
 
 	if err := o.EventLogs.Vent(eventInfo); err != nil {
@@ -365,35 +356,6 @@ func (o *Receiver) verifyJWT(request *http.Request) (*authv1.UserInfo, error) {
 	}
 
 	return &tokenReview.Status.User, nil
-}
-
-func (o *Receiver) getOIDCClaims(request *http.Request) (*eventshub.KubernetesClaims, error) {
-	authHeader := request.Header.Get("Authorization")
-	if authHeader == "" {
-		return nil, fmt.Errorf("could not get Authorization header")
-	}
-
-	token := strings.TrimPrefix(authHeader, "Bearer ")
-	if len(token) == len(authHeader) {
-		return nil, fmt.Errorf("could not get Bearer token from header")
-	}
-
-	parts := strings.Split(token, ".")
-	if len(parts) != 3 {
-		return nil, fmt.Errorf("could not split token into header, payload and signature")
-	}
-
-	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
-	if err != nil {
-		return nil, fmt.Errorf("could not decode payload: %w", err)
-	}
-
-	claims := &eventshub.KubernetesClaims{}
-	if err := json.Unmarshal(payload, &claims); err != nil {
-		return nil, fmt.Errorf("could not unmarshal JSON payload to claim struct: %w", err)
-	}
-
-	return claims, nil
 }
 
 func isTLS(request *http.Request) bool {


### PR DESCRIPTION
Add a event matcher, to check the OIDC user name of the received event.

This adds two new functions:
* `MatchOIDCUser(username)` to directly check if the given username matches the OIDC username in EventInfo
* `MatchOIDCUserFromResource(gvr, resourceName)` to check, if the OIDC username from the given resource matches the OIDC username in the EventInfo

This allows e.g. testcases like the following:
```
...
f.Alpha("Broker").
	Must("subscriber receives event from correct sender identity", eventassert.OnStore(sink).MatchWithContext(eventassert.MatchOIDCUserFromResource(triggerresources.GVR(), triggerName)).Exact(1))
```