### PR TITLE
Create standard global environment with provided rest config

### DIFF
--- a/pkg/environment/standard.go
+++ b/pkg/environment/standard.go
@@ -53,8 +53,16 @@ type ConfigurationOption func(Configuration) Configuration
 // standard way. The Kube client will be initialized within the
 // context.Context for later use.
 func NewStandardGlobalEnvironment(opts ...ConfigurationOption) GlobalEnvironment {
+	return NewStandardGlobalEnvironmentWithRestConfig(nil, opts...)
+}
+
+// NewStandardGlobalEnvironment will create a new global environment in a
+// standard way. The Kube client will be initialized within the
+// context.Context for later use. It uses the provided rest config
+// when creating the informers.
+func NewStandardGlobalEnvironmentWithRestConfig(cfg *rest.Config, opts ...ConfigurationOption) GlobalEnvironment {
 	opts = append(opts, initIstioFlags())
-	config := resolveConfiguration(opts)
+	config := resolveConfiguration(opts, cfg)
 	ctx := testlog.NewContext(config.Context)
 
 	// environment.InitFlags registers state, level and feature filter flags.
@@ -86,11 +94,11 @@ func NewStandardGlobalEnvironment(opts ...ConfigurationOption) GlobalEnvironment
 	return NewGlobalEnvironment(ctx, startInformers)
 }
 
-func resolveConfiguration(opts []ConfigurationOption) Configuration {
+func resolveConfiguration(opts []ConfigurationOption, restCfg *rest.Config) Configuration {
 	cfg := Configuration{
 		Flags:   commandlineFlags{},
 		Context: signals.NewContext(),
-		Config:  nil,
+		Config:  restCfg,
 	}
 	for _, opt := range opts {
 		cfg = opt(cfg)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Add new function which creates a standard global environment using the provided rest config rather than parsing a new config.


This is needed for https://github.com/knative/eventing/pull/7626
