### PR TITLE
Remove deprecated repos from downstream tests

### DIFF
--- a/.github/workflows/knative-downstream.yaml
+++ b/.github/workflows/knative-downstream.yaml
@@ -27,8 +27,6 @@ jobs:
       matrix:
         repo:
           - knative/eventing
-          - knative-sandbox/eventing-rabbitmq
-          - knative-sandbox/eventing-kafka
           - knative-sandbox/eventing-kafka-broker
           - knative-sandbox/kn-plugin-event
 


### PR DESCRIPTION
As per title some cleanup