### PR TITLE
Forwarder: Write received event to request

### DIFF
--- a/pkg/eventshub/forwarder/forwarder.go
+++ b/pkg/eventshub/forwarder/forwarder.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/cloudevents/sdk-go/v2/binding"
 	cloudeventsbindings "github.com/cloudevents/sdk-go/v2/binding"
 	"go.opencensus.io/trace"
 	"go.uber.org/zap"
@@ -170,6 +171,11 @@ func (o *Forwarder) ServeHTTP(writer http.ResponseWriter, request *http.Request)
 		logging.FromContext(o.ctx).Fatalw("Unable to parse sink URL", zap.Error(err))
 	}
 	req.URL = u
+
+	err = cehttp.WriteRequest(requestCtx, binding.ToMessage(event), req)
+	if err != nil {
+		logging.FromContext(o.ctx).Error("Cannot write the event to request: ", err)
+	}
 
 	eventString := "unknown"
 	if event != nil {


### PR DESCRIPTION
Currently we have issues in the forwarder as the request body is read twice (one time to get the message/cloudevent and a second time when the request/clone is sent again (`o.httpClient.Do(req)`)).

This PR addresses it and makes sure the request which is send from the forwarder has the received event in its body.

Hint: I was also checking to clone the request earlier, but `Request.Clone()` seems not really clone the body (https://github.com/golang/go/blob/33013e8ea821629858643f24c55805f5ddf316b5/src/net/http/request.go#L383)