### PR TITLE
fix: KinD tests now use go 1.21.x

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -11,7 +11,7 @@ jobs:
   e2e-tests:
     strategy:
       matrix:
-        go-version: [ 1.20.x ]
+        go-version: [ 1.21.x ]
         platform: [ ubuntu-latest ]
         kind-version: [ 0.14.0 ]
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Upgrade the go version in KinD tests
