### PR TITLE
Bump default Ko version

### DIFF
--- a/pkg/images/ko/publish.go
+++ b/pkg/images/ko/publish.go
@@ -30,7 +30,7 @@ var ErrKoPublishFailed = errors.New("ko publish failed")
 func Publish(ctx context.Context, path string) (string, error) {
 	version := os.Getenv("GOOGLE_KO_VERSION")
 	if version == "" {
-		version = "v0.11.2"
+		version = "v0.15.2"
 	}
 	args := []string{
 		"go", "run", fmt.Sprintf("github.com/google/ko@%s", version),


### PR DESCRIPTION
It's been reported here as a bug https://github.com/knative/eventing/pull/7799#issuecomment-2025228385