### PR TITLE
Add timestamps to log lines

### DIFF
--- a/pkg/environment/execution.go
+++ b/pkg/environment/execution.go
@@ -45,7 +45,7 @@ func (mr *MagicEnvironment) executeStep(ctx context.Context, t *testing.T, f *fe
 	t.Run(s.Name, func(t *testing.T) {
 		t.Parallel()
 		t.Helper()
-		ft := tDecorator(t)
+		ft := newTimestampLoggingT(tDecorator(t))
 		t.Cleanup(func() {
 			mr.milestones.StepFinished(f.Name, s, ft)
 		})


### PR DESCRIPTION
This adds timestamps to each log line emitted by the framework as it helps with debugging and correlating events and system logs with the test's execution

