### PR TITLE
Update OIDC user matcher to work with `.authStatus.serviceAccountNames`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	k8s.io/client-go v0.29.2
 	k8s.io/utils v0.0.0-20240102154912-e7106e64919e
 	knative.dev/hack v0.0.0-20240507013718-68e3bfb39d11
-	knative.dev/pkg v0.0.0-20240507013158-1d1616aa15db
+	knative.dev/pkg v0.0.0-20240507092124-360b72e4948e
 	sigs.k8s.io/yaml v1.4.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -725,8 +725,8 @@ k8s.io/utils v0.0.0-20240102154912-e7106e64919e h1:eQ/4ljkx21sObifjzXwlPKpdGLrCf
 k8s.io/utils v0.0.0-20240102154912-e7106e64919e/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 knative.dev/hack v0.0.0-20240507013718-68e3bfb39d11 h1:CYoD72R8/R35REjeY2nnWfBak+Q3f+NxXwEfwcID1eU=
 knative.dev/hack v0.0.0-20240507013718-68e3bfb39d11/go.mod h1:yk2OjGDsbEnQjfxdm0/HJKS2WqTLEFg/N6nUs6Rqx3Q=
-knative.dev/pkg v0.0.0-20240507013158-1d1616aa15db h1:wc8y5CoKhGWsIUxdkTqILXr2i1rJUxtVKQRc3P0tEKI=
-knative.dev/pkg v0.0.0-20240507013158-1d1616aa15db/go.mod h1:PQiq+p9Gr++TnU+w5P+ZpFS5MOwcMF6Y2oWFU8Ou7bw=
+knative.dev/pkg v0.0.0-20240507092124-360b72e4948e h1:By0c/FKLZlisAerWiMj9crtaEhcl/sp8gN8Rp0s8fKM=
+knative.dev/pkg v0.0.0-20240507092124-360b72e4948e/go.mod h1:PQiq+p9Gr++TnU+w5P+ZpFS5MOwcMF6Y2oWFU8Ou7bw=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/vendor/knative.dev/pkg/apis/duck/v1/auth_types.go
+++ b/vendor/knative.dev/pkg/apis/duck/v1/auth_types.go
@@ -22,4 +22,9 @@ type AuthStatus struct {
 	// ServiceAccountName is the name of the generated service account
 	// used for this components OIDC authentication.
 	ServiceAccountName *string `json:"serviceAccountName,omitempty"`
+
+	// ServiceAccountNames is the list of names of the generated service accounts
+	// used for this components OIDC authentication. This list can have len() > 1,
+	// when the component uses multiple identities (e.g. in case of a Parallel).
+	ServiceAccountNames []string `json:"serviceAccountNames,omitempty"`
 }

--- a/vendor/knative.dev/pkg/apis/duck/v1/zz_generated.deepcopy.go
+++ b/vendor/knative.dev/pkg/apis/duck/v1/zz_generated.deepcopy.go
@@ -158,6 +158,11 @@ func (in *AuthStatus) DeepCopyInto(out *AuthStatus) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.ServiceAccountNames != nil {
+		in, out := &in.ServiceAccountNames, &out.ServiceAccountNames
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -843,7 +843,7 @@ k8s.io/utils/trace
 # knative.dev/hack v0.0.0-20240507013718-68e3bfb39d11
 ## explicit; go 1.18
 knative.dev/hack
-# knative.dev/pkg v0.0.0-20240507013158-1d1616aa15db
+# knative.dev/pkg v0.0.0-20240507092124-360b72e4948e
 ## explicit; go 1.21
 knative.dev/pkg/apis
 knative.dev/pkg/apis/duck


### PR DESCRIPTION
Update the OIDC user matcher to work with .authStatus.serviceAccountName**s** (plural form - https://github.com/knative/pkg/pull/3032)