### PR TITLE
Introduce phase groups for features

### DIFF
--- a/pkg/environment/magic.go
+++ b/pkg/environment/magic.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"regexp"
 	"sync"
 	"testing"
@@ -364,6 +365,15 @@ func (mr *MagicEnvironment) ParallelTest(ctx context.Context, originalT *testing
 // apply it to the Context.
 func (mr *MagicEnvironment) test(ctx context.Context, originalT *testing.T, f *feature.Feature) {
 	originalT.Helper() // Helper marks the calling function as a test helper function.
+
+	for i, g := range f.GetGroups() {
+		originalT.Run(fmt.Sprintf("group-%d", i+1), func(t *testing.T) {
+			mr.test(ctx, t, g)
+		})
+		if originalT.Failed() { // If a group fails, return
+			return
+		}
+	}
 
 	log := logging.FromContext(ctx)
 	f.DumpWith(log.Debug)

--- a/test/e2e/environment_test.go
+++ b/test/e2e/environment_test.go
@@ -55,23 +55,101 @@ func testTimingConstraints(t *testing.T, isParallel bool) {
 	requirementCounter := int32(0)
 	teardownCounter := int32(0)
 
+	setupGroupCounter := int32(0)
+	requirementGroupCounter := int32(0)
+	assertGroupCounter := int32(0)
+	teardownGroupCounter := int32(0)
+
+	feat.Group("my-group", func(f *feature.Feature) {
+		f.Setup("setup group", func(ctx context.Context, t feature.T) {
+			atomic.AddInt32(&setupGroupCounter, 1)
+			// group
+			verifyCounter(&requirementGroupCounter, 0, t)
+			verifyCounter(&assertGroupCounter, 0, t)
+			verifyCounter(&teardownGroupCounter, 0, t)
+
+			// feature
+			verifyCounter(&setupCounter, 0, t)
+			verifyCounter(&requirementCounter, 0, t)
+			verifyCounter(&assertCounter, 0, t)
+			verifyCounter(&teardownCounter, 0, t)
+		})
+		f.Requirement("requirement group", func(ctx context.Context, t feature.T) {
+			atomic.AddInt32(&requirementGroupCounter, 1)
+			// group
+			verifyCounter(&setupGroupCounter, 1, t)
+			verifyCounter(&assertGroupCounter, 0, t)
+			verifyCounter(&teardownGroupCounter, 0, t)
+
+			// feature
+			verifyCounter(&setupCounter, 0, t)
+			verifyCounter(&requirementCounter, 0, t)
+			verifyCounter(&assertCounter, 0, t)
+			verifyCounter(&teardownCounter, 0, t)
+		})
+		f.Assert("assert group", func(ctx context.Context, t feature.T) {
+			atomic.AddInt32(&assertGroupCounter, 1)
+			// group
+			verifyCounter(&setupGroupCounter, 1, t)
+			verifyCounter(&requirementGroupCounter, 1, t)
+			verifyCounter(&teardownGroupCounter, 0, t)
+
+			// feature
+			verifyCounter(&setupCounter, 0, t)
+			verifyCounter(&requirementCounter, 0, t)
+			verifyCounter(&assertCounter, 0, t)
+			verifyCounter(&teardownCounter, 0, t)
+		})
+		f.Teardown("teardown group", func(ctx context.Context, t feature.T) {
+			atomic.AddInt32(&teardownGroupCounter, 1)
+			// group
+			verifyCounter(&setupGroupCounter, 1, t)
+			verifyCounter(&requirementGroupCounter, 1, t)
+			verifyCounter(&assertGroupCounter, 1, t)
+
+			// feature
+			verifyCounter(&setupCounter, 0, t)
+			verifyCounter(&requirementCounter, 0, t)
+			verifyCounter(&assertCounter, 0, t)
+			verifyCounter(&teardownCounter, 0, t)
+		})
+	})
+
 	incrementSetupCounter := func(ctx context.Context, t feature.T) {
 		atomic.AddInt32(&setupCounter, 1)
 		verifyCounter(&requirementCounter, 0, t)
 		verifyCounter(&assertCounter, 0, t)
 		verifyCounter(&teardownCounter, 0, t)
+
+		// group
+		verifyCounter(&setupGroupCounter, 1, t)
+		verifyCounter(&requirementGroupCounter, 1, t)
+		verifyCounter(&assertGroupCounter, 1, t)
+		verifyCounter(&teardownGroupCounter, 1, t)
 	}
 	incrementRequirementCounter := func(ctx context.Context, t feature.T) {
 		verifyCounter(&setupCounter, 3, t)
 		atomic.AddInt32(&requirementCounter, 1)
 		verifyCounter(&assertCounter, 0, t)
 		verifyCounter(&teardownCounter, 0, t)
+
+		// group
+		verifyCounter(&setupGroupCounter, 1, t)
+		verifyCounter(&requirementGroupCounter, 1, t)
+		verifyCounter(&assertGroupCounter, 1, t)
+		verifyCounter(&teardownGroupCounter, 1, t)
 	}
 
 	incrementAssertCounter := func(ctx context.Context, t feature.T) {
 		verifyCounter(&requirementCounter, 5, t)
 		atomic.AddInt32(&assertCounter, 1)
 		verifyCounter(&teardownCounter, 0, t)
+
+		// group
+		verifyCounter(&setupGroupCounter, 1, t)
+		verifyCounter(&requirementGroupCounter, 1, t)
+		verifyCounter(&assertGroupCounter, 1, t)
+		verifyCounter(&teardownGroupCounter, 1, t)
 	}
 
 	incrementTeardownCounter := func(ctx context.Context, t feature.T) {
@@ -79,6 +157,12 @@ func testTimingConstraints(t *testing.T, isParallel bool) {
 		atomic.AddInt32(&teardownCounter, 1)
 		verifyCounter(&setupCounter, 3, t)
 		verifyCounter(&requirementCounter, 5, t)
+
+		// group
+		verifyCounter(&setupGroupCounter, 1, t)
+		verifyCounter(&requirementGroupCounter, 1, t)
+		verifyCounter(&assertGroupCounter, 1, t)
+		verifyCounter(&teardownGroupCounter, 1, t)
 	}
 
 	feat.Setup("setup1", incrementSetupCounter)
@@ -108,6 +192,7 @@ func testTimingConstraints(t *testing.T, isParallel bool) {
 	}
 
 	verifyCounter(&teardownCounter, 2, t)
+	verifyCounter(&teardownGroupCounter, 1, t)
 }
 
 func verifyCounter(counter *int32, expected int32, t feature.T) {


### PR DESCRIPTION
This is a feature that might allow simplifying setting up tests to prevent starvation, for example, this one https://github.com/knative/eventing/pull/7911 while continuing to get the benefits of the parallel phases and avoiding having the error prone calls like `eventshub.Install(subscriberName2, eventshub.StartReceiver)(ctx, t)`

```golang
f.Group("install subscribers", func(f *Feature) {
   f.Setup("install eventshub", eventshub.Install(subscriberName1, eventshub.StartReceiver))
})

f.Group("install brokers", func(f *Feature) {
   f.Setup("install broker1", broker.Install(...))
   f.Setup("install broker2", broker.Install(...))
})

f.Group("ready brokers", func(f *Feature) {
   f.Requirement("ready broker1", broker.IsReady(...))
   f.Requirement("ready broker2", broker.IsReady(...))
   f.Assert("addressable broker1", broker.IsAddressable(...))
   f.Assert("addressable broker2", broker.IsAddressable(...))
})

f.Group("install triggers", func(f *Feature) {
   f.Setup("install trigger1", trigger.Install(...))
   f.Setup("install trigger2", trigger.Install(...))
})

f.Group("ready triggers", func(f *Feature) {
   f.Setup("ready trigger1", trigger.IsReady(...))
   f.Setup("ready trigger2", trigger.IsReady(...))
})


f.Assert(...)
```

See also usage example in `test/e2e/environment_test.go`