### PR TITLE
Increase default QPS and Burst to avoid getting rate limited

### DIFF
--- a/pkg/environment/standard.go
+++ b/pkg/environment/standard.go
@@ -87,6 +87,22 @@ func NewStandardGlobalEnvironmentWithRestConfig(cfg *rest.Config, opts ...Config
 	// features to pull Kubernetes clients or the test environment out of the
 	// context passed in the features.
 	var startInformers func()
+
+	if config.Config == nil {
+		config.Config = injection.ParseAndGetRESTConfigOrDie()
+	}
+	// Respect user provided settings, but if omitted customize the default behavior.
+	//
+	// Use 20 times the default QPS and Burst to speed up testing since this client is used by
+	// every running test.
+	multiplier := 20
+	if config.Config.QPS == 0 {
+		config.Config.QPS = rest.DefaultQPS * float32(multiplier)
+	}
+	if config.Config.Burst == 0 {
+		config.Config.Burst = rest.DefaultBurst * multiplier
+	}
+
 	ctx, startInformers = injection.EnableInjectionOrDie(ctx, config.Config)
 
 	// global is used to make instances of Environments, NewGlobalEnvironment

--- a/pkg/environment/timings.go
+++ b/pkg/environment/timings.go
@@ -26,7 +26,7 @@ import (
 // this has been moved to state pkg to break cycle between environment and feature package,
 // keeping the consts here for backwards API compatibility
 const (
-	DefaultPollInterval = 3 * time.Second
+	DefaultPollInterval = 1 * time.Second
 	DefaultPollTimeout  = 2 * time.Minute
 )
 


### PR DESCRIPTION
The test client used by every running test and we've seen many instances where we get rate-limited for no reason.

