### PR TITLE
Fix `nil` pointer error in forwarder from file

### DIFF
--- a/pkg/eventshub/forwarder/forwarder.go
+++ b/pkg/eventshub/forwarder/forwarder.go
@@ -308,7 +308,6 @@ func (o *Forwarder) forwardFromFile(f string) {
 	}
 
 	eventInfo := eventshub.EventInfo{
-		Error:    err.Error(),
 		Event:    event,
 		Observer: o.Name,
 		Origin:   f,


### PR DESCRIPTION
`err` is `nil`.