### PR TITLE
Allow to configure OIDC subject name for eventshub sender

### DIFF
--- a/pkg/eventshub/options.go
+++ b/pkg/eventshub/options.go
@@ -334,7 +334,7 @@ func OIDCCorruptedSignature() EventsHubOption {
 	return compose(envOption(OIDCGenerateCorruptedSignatureTokenEnv, "true"), envOIDCEnabled())
 }
 
-// OIDCSubject sets the name of the OIDC subject to use by the sender. Defaults to "oidc-<eventshub-name>"
+// OIDCSubject sets the name of the OIDC subject to use by the sender. If this option is not set, it defaults to "oidc-<eventshub-name>"
 func OIDCSubject(sub string) EventsHubOption {
 	return compose(envOption(OIDCSubjectEnv, sub), envOIDCEnabled())
 }

--- a/pkg/eventshub/options.go
+++ b/pkg/eventshub/options.go
@@ -334,6 +334,11 @@ func OIDCCorruptedSignature() EventsHubOption {
 	return compose(envOption(OIDCGenerateCorruptedSignatureTokenEnv, "true"), envOIDCEnabled())
 }
 
+// OIDCSubject sets the name of the OIDC subject to use by the sender. Defaults to "oidc-<eventshub-name>"
+func OIDCSubject(sub string) EventsHubOption {
+	return compose(envOption(OIDCSubjectEnv, sub), envOIDCEnabled())
+}
+
 // OIDCToken adds the given token used for OIDC authentication to the request.
 func OIDCToken(jwt string) EventsHubOption {
 	return compose(envOption(OIDCTokenEnv, jwt), envOIDCEnabled())

--- a/pkg/eventshub/resources.go
+++ b/pkg/eventshub/resources.go
@@ -136,6 +136,9 @@ func Install(name string, options ...EventsHubOption) feature.StepFn {
 		if isOIDCEnabled && !isReceiver {
 			// install oidc sa
 			oidcSAName := fmt.Sprintf("oidc-%s", name)
+			if envs[OIDCSubjectEnv] != "" {
+				oidcSAName = envs[OIDCSubjectEnv]
+			}
 			serviceaccount.Install(oidcSAName)(ctx, t)
 
 			// generate token

--- a/pkg/eventshub/utils.go
+++ b/pkg/eventshub/utils.go
@@ -41,6 +41,7 @@ const (
 	OIDCEnabledEnv                         = "ENABLE_OIDC_AUTH"
 	OIDCGenerateExpiredTokenEnv            = "OIDC_GENERATE_EXPIRED_TOKEN"
 	OIDCGenerateInvalidAudienceTokenEnv    = "OIDC_GENERATE_INVALID_AUDIENCE_TOKEN"
+	OIDCSubjectEnv                         = "OIDC_SUBJECT"
 	OIDCGenerateCorruptedSignatureTokenEnv = "OIDC_GENERATE_CORRUPTED_SIG_TOKEN"
 	OIDCSinkAudienceEnv                    = "OIDC_SINK_AUDIENCE"
 	OIDCReceiverAudienceEnv                = "OIDC_AUDIENCE"


### PR DESCRIPTION
Adds an option to set the OIDC identity to use for the eventshub sender