### PR TITLE
feat: add support for verifying the event format in the eventshub receiver

### DIFF
--- a/pkg/eventshub/options.go
+++ b/pkg/eventshub/options.go
@@ -234,6 +234,21 @@ func OIDCReceiverAudience(aud string) EventsHubOption {
 	return compose(envOption(OIDCReceiverAudienceEnv, aud), envOIDCEnabled())
 }
 
+// VerifyEventFormat has the receiver verify the event format when receiving events
+func VerifyEventFormat(format string) EventsHubOption {
+	return compose(envOption("EVENT_FORMAT", format))
+}
+
+// VerifyEventFormat has the receiver verify the event format is structured when receiving events
+func VerifyEventFormatStructured() EventsHubOption {
+	return VerifyEventFormat("json")
+}
+
+// VerifyEventFormat has the receiver verify the event format is binary when receiving events
+func VerifyEventFormatBinary() EventsHubOption {
+	return VerifyEventFormat("binary")
+}
+
 // --- Sender options
 
 // InitialSenderDelay defines how much the sender has to wait (in millisecond), when started, before start sending events.


### PR DESCRIPTION


<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

This is needed to test changes like https://github.com/knative/eventing/pull/8151

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Add options for verifying the event format in the eventshub receiver
- Add code to the receiver to verify the event format when the right env var is set

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:
