### PR TITLE
fix: eventshub receiver does not panic when rejecting event for bad format

### DIFF
--- a/pkg/eventshub/receiver/receiver.go
+++ b/pkg/eventshub/receiver/receiver.go
@@ -249,6 +249,10 @@ func (o *Receiver) ServeHTTP(writer http.ResponseWriter, request *http.Request) 
 	defer m.Finish(nil)
 
 	encoding := m.ReadEncoding()
+	if !verifyFormat(o.expectedFormat, encoding) {
+		rejectErr = fmt.Errorf("delivered event in wrong format, expected %s, received %s", *o.expectedFormat, encoding)
+		statusCode = http.StatusBadRequest
+	}
 
 	event, eventErr := cloudeventsbindings.ToEvent(context.TODO(), m)
 	headers := make(http.Header)


### PR DESCRIPTION


<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->
The eventshub receiver panics when rejecting an event due to the wrong format as the status code has not been set, leading to writing a status code of `0`.

# Changes



<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Set the status code when an even will be rejected for the wrong format
