### PR TITLE
retry update conflicts in manifest Apply

### DIFF
--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -19,8 +19,9 @@ package manifest
 import (
 	"context"
 	"fmt"
-	"knative.dev/pkg/reconciler"
 	"strings"
+
+	"knative.dev/pkg/reconciler"
 
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v3"


### PR DESCRIPTION
Seeing https://prow.knative.dev/view/gs/knative-prow/pr-logs/pull/knative-extensions_eventing-kafka-broker/4461/reconciler-tests-namespaced-broker_eventing-kafka-broker_main/1948812764961050624 

>  trigger.go:213: failed to update resource Operation cannot be fulfilled on triggers.eventing.knative.dev "trigger-fionpyxa": the object has been modified; please apply your changes to the latest version and try again - Resource:

Not many tests re-create a resource with the same name, TestBrokerDeletedRecreated re-creates a Trigger, so it sometimes hits an "object is modified" error on update.

- :broom: Retry update conflicts in manifest Apply
