### PR TITLE
Update default ko version to 0.18.0

### DIFF
--- a/pkg/images/ko/publish.go
+++ b/pkg/images/ko/publish.go
@@ -30,7 +30,7 @@ var ErrKoPublishFailed = errors.New("ko publish failed")
 func Publish(ctx context.Context, path string) (string, error) {
 	version := os.Getenv("GOOGLE_KO_VERSION")
 	if version == "" {
-		version = "v0.15.2"
+		version = "v0.18.0"
 	}
 	args := []string{
 		"go", "run", fmt.Sprintf("github.com/google/ko@%s", version),


### PR DESCRIPTION
When running some rekt tests locally, I am getting an error on ko publish, which seems to be due to a version mismatch: 

```
logger.go:146: 2025-09-09T12:27:36.524+0200	DEBUG	ko/cmd.go:55	# golang.org/x/tools/internal/tokeninternal	{"test": "TestIntegrationSinkSuccess"}
    logger.go:146: 2025-09-09T12:27:36.524+0200	DEBUG	ko/cmd.go:55	../../../../go/pkg/mod/golang.org/x/tools@v0.18.0/internal/tokeninternal/tokeninternal.go:78:9: invalid array length -delta * delta (constant -256 of type int64)	{"test": "TestIntegrationSinkSuccess"}
    logger.go:146: 2025-09-09T12:27:36.533+0200	WARN	environment/images.go:100	Ko publish failed, using image directly	{"test": "TestIntegrationSinkSuccess", "error": "ko publish failed: exit status 1 -- command: [\"go\" \"run\" \"github.com/google/ko@v0.15.2\" \"publish\" \"-B\" \"knative.dev/reconciler-test/cmd/eventshub\"]", "image": "knative.dev/reconciler-test/cmd/eventshub"}
```

Updating the default ko version to a newer version seems to fix the issue (locally I am on 0.18.0 too)