### PR TITLE
chore: Update cert-manager resources to 1.20.3

### DIFF
--- a/hack/update-cert-manager.sh
+++ b/hack/update-cert-manager.sh
@@ -23,4 +23,4 @@ metadata:
 EOF
 }
 
-update_cert_manager "v1.20.2" "v0.22.1"
+update_cert_manager "v1.20.3" "v0.24.0"

--- a/hack/update-cert-manager.sh
+++ b/hack/update-cert-manager.sh
@@ -23,4 +23,4 @@ metadata:
 EOF
 }
 
-update_cert_manager "v1.20.3" "v0.24.0"
+update_cert_manager "${1:-${CERT_MANAGER_VERSION:-v1.20.3}}" "${2:-${TRUST_MANAGER_VERSION:-v0.24.0}}"

--- a/third_party/cert-manager/01-cert-manager.yaml
+++ b/third_party/cert-manager/01-cert-manager.yaml
@@ -11,9 +11,9 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.20.2"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.20.2
+    helm.sh/chart: cert-manager-v1.20.3
 ---
 # Source: cert-manager/templates/serviceaccount.yaml
 apiVersion: v1
@@ -27,9 +27,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.20.2"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.20.2
+    helm.sh/chart: cert-manager-v1.20.3
 ---
 # Source: cert-manager/templates/webhook-serviceaccount.yaml
 apiVersion: v1
@@ -43,9 +43,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.20.2"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.20.2
+    helm.sh/chart: cert-manager-v1.20.3
 ---
 # Source: cert-manager/templates/crd-acme.cert-manager.io_challenges.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -59,9 +59,9 @@ metadata:
     app.kubernetes.io/name: "cert-manager"
     app.kubernetes.io/instance: "cert-manager"
     app.kubernetes.io/component: "crds"
-    app.kubernetes.io/version: "v1.20.2"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.20.2
+    helm.sh/chart: cert-manager-v1.20.3
 spec:
   group: acme.cert-manager.io
   names:
@@ -3366,9 +3366,9 @@ metadata:
     app.kubernetes.io/name: "cert-manager"
     app.kubernetes.io/instance: "cert-manager"
     app.kubernetes.io/component: "crds"
-    app.kubernetes.io/version: "v1.20.2"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.20.2
+    helm.sh/chart: cert-manager-v1.20.3
 spec:
   group: acme.cert-manager.io
   names:
@@ -3648,9 +3648,9 @@ metadata:
     app.kubernetes.io/name: "cert-manager"
     app.kubernetes.io/instance: "cert-manager"
     app.kubernetes.io/component: "crds"
-    app.kubernetes.io/version: "v1.20.2"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.20.2
+    helm.sh/chart: cert-manager-v1.20.3
 spec:
   group: cert-manager.io
   names:
@@ -3975,9 +3975,9 @@ metadata:
     app.kubernetes.io/name: "cert-manager"
     app.kubernetes.io/instance: "cert-manager"
     app.kubernetes.io/component: "crds"
-    app.kubernetes.io/version: "v1.20.2"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.20.2
+    helm.sh/chart: cert-manager-v1.20.3
 spec:
   group: cert-manager.io
   names:
@@ -4796,9 +4796,9 @@ metadata:
     app.kubernetes.io/name: "cert-manager"
     app.kubernetes.io/instance: "cert-manager"
     app.kubernetes.io/component: "crds"
-    app.kubernetes.io/version: "v1.20.2"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.20.2
+    helm.sh/chart: cert-manager-v1.20.3
 spec:
   group: cert-manager.io
   names:
@@ -8633,9 +8633,9 @@ metadata:
     app.kubernetes.io/name: "cert-manager"
     app.kubernetes.io/instance: "cert-manager"
     app.kubernetes.io/component: "crds"
-    app.kubernetes.io/version: "v1.20.2"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.20.2
+    helm.sh/chart: cert-manager-v1.20.3
 spec:
   group: cert-manager.io
   names:
@@ -12467,9 +12467,9 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.20.2"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.20.2
+    helm.sh/chart: cert-manager-v1.20.3
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates"]
@@ -12501,9 +12501,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.20.2"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.20.2
+    helm.sh/chart: cert-manager-v1.20.3
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["issuers", "issuers/status"]
@@ -12529,9 +12529,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.20.2"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.20.2
+    helm.sh/chart: cert-manager-v1.20.3
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["clusterissuers", "clusterissuers/status"]
@@ -12557,9 +12557,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.20.2"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.20.2
+    helm.sh/chart: cert-manager-v1.20.3
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "certificates/status", "certificaterequests", "certificaterequests/status"]
@@ -12594,9 +12594,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.20.2"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.20.2
+    helm.sh/chart: cert-manager-v1.20.3
 rules:
   - apiGroups: ["acme.cert-manager.io"]
     resources: ["orders", "orders/status"]
@@ -12637,9 +12637,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.20.2"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.20.2
+    helm.sh/chart: cert-manager-v1.20.3
 rules:
   # Use to update challenge resource status
   - apiGroups: ["acme.cert-manager.io"]
@@ -12699,9 +12699,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.20.2"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.20.2
+    helm.sh/chart: cert-manager-v1.20.3
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "certificaterequests"]
@@ -12738,9 +12738,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.20.2"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.20.2
+    helm.sh/chart: cert-manager-v1.20.3
     rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
 rules:
   - apiGroups: ["cert-manager.io"]
@@ -12757,9 +12757,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.20.2"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.20.2
+    helm.sh/chart: cert-manager-v1.20.3
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
@@ -12782,9 +12782,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.20.2"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.20.2
+    helm.sh/chart: cert-manager-v1.20.3
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:
@@ -12795,8 +12795,11 @@ rules:
     resources: ["certificates/status"]
     verbs: ["update"]
   - apiGroups: ["acme.cert-manager.io"]
-    resources: ["challenges", "orders"]
-    verbs: ["create", "delete", "deletecollection", "patch", "update"]
+    resources: ["challenges"]
+    verbs: ["delete", "deletecollection", "patch", "update"]
+  - apiGroups: ["acme.cert-manager.io"]
+    resources: ["orders"]
+    verbs: ["delete", "deletecollection"]
 ---
 # Source: cert-manager/templates/rbac.yaml
 # Permission to approve CertificateRequests referencing cert-manager.io Issuers and ClusterIssuers
@@ -12809,9 +12812,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.20.2"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.20.2
+    helm.sh/chart: cert-manager-v1.20.3
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["signers"]
@@ -12833,9 +12836,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.20.2"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.20.2
+    helm.sh/chart: cert-manager-v1.20.3
 rules:
   - apiGroups: ["certificates.k8s.io"]
     resources: ["certificatesigningrequests"]
@@ -12861,9 +12864,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.20.2"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.20.2
+    helm.sh/chart: cert-manager-v1.20.3
 rules:
 - apiGroups: ["authorization.k8s.io"]
   resources: ["subjectaccessreviews"]
@@ -12879,9 +12882,9 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.20.2"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.20.2
+    helm.sh/chart: cert-manager-v1.20.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -12901,9 +12904,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.20.2"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.20.2
+    helm.sh/chart: cert-manager-v1.20.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -12923,9 +12926,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.20.2"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.20.2
+    helm.sh/chart: cert-manager-v1.20.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -12945,9 +12948,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.20.2"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.20.2
+    helm.sh/chart: cert-manager-v1.20.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -12967,9 +12970,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.20.2"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.20.2
+    helm.sh/chart: cert-manager-v1.20.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -12989,9 +12992,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.20.2"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.20.2
+    helm.sh/chart: cert-manager-v1.20.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -13011,9 +13014,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.20.2"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.20.2
+    helm.sh/chart: cert-manager-v1.20.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -13033,9 +13036,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.20.2"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.20.2
+    helm.sh/chart: cert-manager-v1.20.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -13055,9 +13058,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.20.2"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.20.2
+    helm.sh/chart: cert-manager-v1.20.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -13077,9 +13080,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.20.2"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.20.2
+    helm.sh/chart: cert-manager-v1.20.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -13101,9 +13104,9 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.20.2"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.20.2
+    helm.sh/chart: cert-manager-v1.20.3
 rules:
   # Used for leader election by the controller
   # cert-manager-cainjector-leader-election is used by the CertificateBased injector controller
@@ -13129,9 +13132,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.20.2"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.20.2
+    helm.sh/chart: cert-manager-v1.20.3
 rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
@@ -13152,9 +13155,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.20.2"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.20.2
+    helm.sh/chart: cert-manager-v1.20.3
 rules:
   - apiGroups: [""]
     resources: ["serviceaccounts/token"]
@@ -13172,9 +13175,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.20.2"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.20.2
+    helm.sh/chart: cert-manager-v1.20.3
 rules:
 - apiGroups: [""]
   resources: ["secrets"]
@@ -13199,9 +13202,9 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.20.2"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.20.2
+    helm.sh/chart: cert-manager-v1.20.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -13224,9 +13227,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.20.2"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.20.2
+    helm.sh/chart: cert-manager-v1.20.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -13248,9 +13251,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.20.2"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.20.2
+    helm.sh/chart: cert-manager-v1.20.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -13271,9 +13274,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.20.2"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.20.2
+    helm.sh/chart: cert-manager-v1.20.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -13294,9 +13297,9 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.20.2"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.20.2
+    helm.sh/chart: cert-manager-v1.20.3
 spec:
   type: ClusterIP
   ports:
@@ -13319,9 +13322,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.20.2"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.20.2
+    helm.sh/chart: cert-manager-v1.20.3
 spec:
   type: ClusterIP
   ports:
@@ -13345,9 +13348,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.20.2"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.20.2
+    helm.sh/chart: cert-manager-v1.20.3
 spec:
   type: ClusterIP
   ports:
@@ -13375,9 +13378,9 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.20.2"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.20.2
+    helm.sh/chart: cert-manager-v1.20.3
 spec:
   replicas: 1
   selector:
@@ -13392,9 +13395,9 @@ spec:
         app.kubernetes.io/name: cainjector
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/component: "cainjector"
-        app.kubernetes.io/version: "v1.20.2"
+        app.kubernetes.io/version: "v1.20.3"
         app.kubernetes.io/managed-by: Helm
-        helm.sh/chart: cert-manager-v1.20.2
+        helm.sh/chart: cert-manager-v1.20.3
       annotations:
         prometheus.io/path: "/metrics"
         prometheus.io/scrape: 'true'
@@ -13408,7 +13411,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: cert-manager-cainjector
-          image: "quay.io/jetstack/cert-manager-cainjector:v1.20.2"
+          image: "quay.io/jetstack/cert-manager-cainjector:v1.20.3"
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
@@ -13442,9 +13445,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.20.2"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.20.2
+    helm.sh/chart: cert-manager-v1.20.3
 spec:
   replicas: 1
   selector:
@@ -13459,9 +13462,9 @@ spec:
         app.kubernetes.io/name: cert-manager
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/component: "controller"
-        app.kubernetes.io/version: "v1.20.2"
+        app.kubernetes.io/version: "v1.20.3"
         app.kubernetes.io/managed-by: Helm
-        helm.sh/chart: cert-manager-v1.20.2
+        helm.sh/chart: cert-manager-v1.20.3
       annotations:
         prometheus.io/path: "/metrics"
         prometheus.io/scrape: 'true'
@@ -13475,13 +13478,13 @@ spec:
           type: RuntimeDefault
       containers:
         - name: cert-manager-controller
-          image: "quay.io/jetstack/cert-manager-controller:v1.20.2"
+          image: "quay.io/jetstack/cert-manager-controller:v1.20.3"
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
           - --cluster-resource-namespace=$(POD_NAMESPACE)
           - --leader-election-namespace=kube-system
-          - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.20.2
+          - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.20.3
           - --max-concurrent-challenges=60
           ports:
           - containerPort: 9402
@@ -13528,9 +13531,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.20.2"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.20.2
+    helm.sh/chart: cert-manager-v1.20.3
 spec:
   replicas: 1
   selector:
@@ -13545,9 +13548,9 @@ spec:
         app.kubernetes.io/name: webhook
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/component: "webhook"
-        app.kubernetes.io/version: "v1.20.2"
+        app.kubernetes.io/version: "v1.20.3"
         app.kubernetes.io/managed-by: Helm
-        helm.sh/chart: cert-manager-v1.20.2
+        helm.sh/chart: cert-manager-v1.20.3
       annotations:
         prometheus.io/path: "/metrics"
         prometheus.io/scrape: 'true'
@@ -13561,7 +13564,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: cert-manager-webhook
-          image: "quay.io/jetstack/cert-manager-webhook:v1.20.2"
+          image: "quay.io/jetstack/cert-manager-webhook:v1.20.3"
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
@@ -13625,9 +13628,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.20.2"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.20.2
+    helm.sh/chart: cert-manager-v1.20.3
   annotations:
     cert-manager.io/inject-ca-from-secret: "cert-manager/cert-manager-webhook-ca"
 webhooks:
@@ -13666,9 +13669,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.20.2"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.20.2
+    helm.sh/chart: cert-manager-v1.20.3
   annotations:
     cert-manager.io/inject-ca-from-secret: "cert-manager/cert-manager-webhook-ca"
 webhooks:
@@ -13720,9 +13723,9 @@ metadata:
     app.kubernetes.io/name: startupapicheck
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "startupapicheck"
-    app.kubernetes.io/version: "v1.20.2"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.20.2
+    helm.sh/chart: cert-manager-v1.20.3
 ---
 # Source: cert-manager/templates/startupapicheck-rbac.yaml
 # create certificate role
@@ -13736,9 +13739,9 @@ metadata:
     app.kubernetes.io/name: startupapicheck
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "startupapicheck"
-    app.kubernetes.io/version: "v1.20.2"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.20.2
+    helm.sh/chart: cert-manager-v1.20.3
   annotations:
     helm.sh/hook: post-install
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
@@ -13759,9 +13762,9 @@ metadata:
     app.kubernetes.io/name: startupapicheck
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "startupapicheck"
-    app.kubernetes.io/version: "v1.20.2"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.20.2
+    helm.sh/chart: cert-manager-v1.20.3
   annotations:
     helm.sh/hook: post-install
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
@@ -13786,9 +13789,9 @@ metadata:
     app.kubernetes.io/name: startupapicheck
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "startupapicheck"
-    app.kubernetes.io/version: "v1.20.2"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.20.2
+    helm.sh/chart: cert-manager-v1.20.3
   annotations:
     helm.sh/hook: post-install
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
@@ -13802,9 +13805,9 @@ spec:
         app.kubernetes.io/name: startupapicheck
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/component: "startupapicheck"
-        app.kubernetes.io/version: "v1.20.2"
+        app.kubernetes.io/version: "v1.20.3"
         app.kubernetes.io/managed-by: Helm
-        helm.sh/chart: cert-manager-v1.20.2
+        helm.sh/chart: cert-manager-v1.20.3
     spec:
       restartPolicy: OnFailure
       serviceAccountName: cert-manager-startupapicheck
@@ -13815,7 +13818,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: cert-manager-startupapicheck
-          image: "quay.io/jetstack/cert-manager-startupapicheck:v1.20.2"
+          image: "quay.io/jetstack/cert-manager-startupapicheck:v1.20.3"
           imagePullPolicy: IfNotPresent
           args:
           - check

--- a/third_party/cert-manager/02-trust-manager.yaml
+++ b/third_party/cert-manager/02-trust-manager.yaml
@@ -8,9 +8,9 @@ metadata:
   namespace: cert-manager
   labels:
     app.kubernetes.io/name: trust-manager
-    helm.sh/chart: trust-manager-v0.22.1
+    helm.sh/chart: trust-manager-v0.24.0
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/version: "v0.22.1"
+    app.kubernetes.io/version: "v0.24.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: trust-manager/templates/crd-trust.cert-manager.io_bundles.yaml
@@ -22,9 +22,9 @@ metadata:
     helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/name: trust-manager
-    helm.sh/chart: trust-manager-v0.22.1
+    helm.sh/chart: trust-manager-v0.24.0
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/version: "v0.22.1"
+    app.kubernetes.io/version: "v0.24.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   group: trust.cert-manager.io
@@ -529,15 +529,38 @@ spec:
       subresources:
         status: {}
 ---
+# Source: trust-manager/templates/clusterrole-aggregate.yaml
+# Bundle is a cluster-scoped resource, so its read access is aggregated into
+# the "cluster-reader" ClusterRole (mirroring how cert-manager aggregates its
+# cluster-scoped ClusterIssuers), rather than into the namespaced
+# view/edit/admin roles.
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+    app.kubernetes.io/name: trust-manager
+    helm.sh/chart: trust-manager-v0.24.0
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/version: "v0.24.0"
+    app.kubernetes.io/managed-by: Helm
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
+  name: trust-manager-cluster-view
+rules:
+- apiGroups:
+  - "trust.cert-manager.io"
+  resources:
+  - "bundles"
+  verbs: ["get", "list", "watch"]
+---
 # Source: trust-manager/templates/clusterrole.yaml
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
     app.kubernetes.io/name: trust-manager
-    helm.sh/chart: trust-manager-v0.22.1
+    helm.sh/chart: trust-manager-v0.24.0
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/version: "v0.22.1"
+    app.kubernetes.io/version: "v0.24.0"
     app.kubernetes.io/managed-by: Helm
   name: trust-manager
 rules:
@@ -585,9 +608,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
     app.kubernetes.io/name: trust-manager
-    helm.sh/chart: trust-manager-v0.22.1
+    helm.sh/chart: trust-manager-v0.24.0
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/version: "v0.22.1"
+    app.kubernetes.io/version: "v0.24.0"
     app.kubernetes.io/managed-by: Helm
   name: trust-manager
 roleRef:
@@ -607,9 +630,9 @@ metadata:
   namespace: cert-manager
   labels:
     app.kubernetes.io/name: trust-manager
-    helm.sh/chart: trust-manager-v0.22.1
+    helm.sh/chart: trust-manager-v0.24.0
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/version: "v0.22.1"
+    app.kubernetes.io/version: "v0.24.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -629,9 +652,9 @@ metadata:
   namespace: cert-manager
   labels:
     app.kubernetes.io/name: trust-manager
-    helm.sh/chart: trust-manager-v0.22.1
+    helm.sh/chart: trust-manager-v0.24.0
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/version: "v0.22.1"
+    app.kubernetes.io/version: "v0.24.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -653,9 +676,9 @@ metadata:
   namespace: cert-manager
   labels:
     app.kubernetes.io/name: trust-manager
-    helm.sh/chart: trust-manager-v0.22.1
+    helm.sh/chart: trust-manager-v0.24.0
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/version: "v0.22.1"
+    app.kubernetes.io/version: "v0.24.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -674,9 +697,9 @@ metadata:
   namespace: cert-manager
   labels:
     app.kubernetes.io/name: trust-manager
-    helm.sh/chart: trust-manager-v0.22.1
+    helm.sh/chart: trust-manager-v0.24.0
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/version: "v0.22.1"
+    app.kubernetes.io/version: "v0.24.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -695,10 +718,11 @@ metadata:
   namespace: cert-manager
   labels:
     app: trust-manager
+    app.kubernetes.io/component: metrics
     app.kubernetes.io/name: trust-manager
-    helm.sh/chart: trust-manager-v0.22.1
+    helm.sh/chart: trust-manager-v0.24.0
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/version: "v0.22.1"
+    app.kubernetes.io/version: "v0.24.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -719,9 +743,9 @@ metadata:
   labels:
     app: trust-manager
     app.kubernetes.io/name: trust-manager
-    helm.sh/chart: trust-manager-v0.22.1
+    helm.sh/chart: trust-manager-v0.24.0
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/version: "v0.22.1"
+    app.kubernetes.io/version: "v0.24.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -741,9 +765,9 @@ metadata:
   namespace: cert-manager
   labels:
     app.kubernetes.io/name: trust-manager
-    helm.sh/chart: trust-manager-v0.22.1
+    helm.sh/chart: trust-manager-v0.24.0
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/version: "v0.22.1"
+    app.kubernetes.io/version: "v0.24.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -756,16 +780,16 @@ spec:
       labels:
         app: trust-manager
         app.kubernetes.io/name: trust-manager
-        helm.sh/chart: trust-manager-v0.22.1
+        helm.sh/chart: trust-manager-v0.24.0
         app.kubernetes.io/instance: cert-manager
-        app.kubernetes.io/version: "v0.22.1"
+        app.kubernetes.io/version: "v0.24.0"
         app.kubernetes.io/managed-by: Helm
     spec:
       serviceAccountName: trust-manager
       automountServiceAccountToken: true
       initContainers:
       - name: cert-manager-package-debian
-        image: "quay.io/jetstack/trust-pkg-debian-bookworm:20230311-deb12u1.6"
+        image: "quay.io/jetstack/trust-pkg-debian-trixie:20250419.1"
         imagePullPolicy: IfNotPresent
         args:
           - "/copyandmaybepause"
@@ -786,7 +810,7 @@ spec:
             type: RuntimeDefault
       containers:
       - name: trust-manager
-        image: "quay.io/jetstack/trust-manager:v0.22.1"
+        image: "quay.io/jetstack/trust-manager:v0.24.0"
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6443
@@ -852,9 +876,9 @@ metadata:
   namespace: cert-manager
   labels:
     app.kubernetes.io/name: trust-manager
-    helm.sh/chart: trust-manager-v0.22.1
+    helm.sh/chart: trust-manager-v0.24.0
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/version: "v0.22.1"
+    app.kubernetes.io/version: "v0.24.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   commonName: "trust-manager.cert-manager.svc"
@@ -877,9 +901,9 @@ metadata:
   namespace: cert-manager
   labels:
     app.kubernetes.io/name: trust-manager
-    helm.sh/chart: trust-manager-v0.22.1
+    helm.sh/chart: trust-manager-v0.24.0
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/version: "v0.22.1"
+    app.kubernetes.io/version: "v0.24.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selfSigned: {}
@@ -892,9 +916,9 @@ metadata:
   labels:
     app: trust-manager
     app.kubernetes.io/name: trust-manager
-    helm.sh/chart: trust-manager-v0.22.1
+    helm.sh/chart: trust-manager-v0.24.0
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/version: "v0.22.1"
+    app.kubernetes.io/version: "v0.24.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     cert-manager.io/inject-ca-from: "cert-manager/trust-manager"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- chore: Update cert-manager resources to 1.20.3

Same version as proposed for Eventing version bump. 

/cc @gauron99 